### PR TITLE
Address follow-up items from PR #11

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @craigmcn

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,13 +17,6 @@ yarn format       # Prettier on src/ and index.html
 
 Tests are co-located with components (`src/components/**/*.test.tsx`) and utilities (`src/lib/index.test.ts`). Test environment setup lives in `tests/setup.ts`.
 
-## Follow-up items
-
-These are known issues that are non-blocking but should be addressed in a future PR:
-
-- **Sass deprecation warnings** — `src/styles/index.scss` uses `@import` (deprecated in Dart Sass 3) and `src/styles/_variables.scss` uses `darken()`/`desaturate()` (deprecated color functions). Migrate to `@use`/`@forward` and `color.adjust()`.
-- **`Result.test.tsx` click coverage** — the "Play again" button is rendered in all tests but `handleAgain` is never asserted to have been called. Add a `userEvent.click` test for the button.
-
 ## Architecture
 
 This is a single-page React 19 + TypeScript app built with Vite 8. It implements a classic "number magic" card trick: the user picks a number 1–63 in their head; the app shows six cards and asks "is your number on this card?"; the sum of the first element of each "yes" card reveals the chosen number (binary representation).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,23 @@ yarn format       # Prettier on src/ and index.html
 
 Tests are co-located with components (`src/components/**/*.test.tsx`) and utilities (`src/lib/index.test.ts`). Test environment setup lives in `tests/setup.ts`.
 
+## Status
+
+**Modernization: complete.** The repo matches the standard baseline (Node 24, Yarn 4, Vite 8, TypeScript 5, ESLint 9 flat config, Vitest + Testing Library, `test.yml` CI, CLAUDE.md, branch protection).
+
+**PR #12 open** (`followup-items` branch) — pending merge:
+- `.github/CODEOWNERS` added (`* @craigmcn`)
+- Sass `@import` → `@use 'variables' as *`; deprecated `darken()`/`desaturate()`/`lighten()` replaced with `color.adjust()` from `sass:color`
+- `userEvent.click` test added for the "Play again" button in `Result.test.tsx`
+- README rewritten with end-user usage and developer sections
+
+**Branch protection** (done outside PR, 2026-05-01):
+- Required approvals: 0 → 1
+- Owner bypass: `enforce_admins: false` (Craig can merge without a review)
+- Dismiss stale reviews, require `test` status check, block force push + deletion
+
+**Next:** Merge PR #12. No known outstanding items after that.
+
 ## Architecture
 
 This is a single-page React 19 + TypeScript app built with Vite 8. It implements a classic "number magic" card trick: the user picks a number 1–63 in their head; the app shows six cards and asks "is your number on this card?"; the sum of the first element of each "yes" card reveals the chosen number (binary representation).

--- a/README.md
+++ b/README.md
@@ -1,32 +1,50 @@
-# number-magic
-A magic number guessing game
+# Number Magic
 
-Find it at [Number Magic](https://www.craigmcn.com/number-magic/)
+A classic number magic card trick, in your browser.
+
+[craigmcn.com/number-magic](https://www.craigmcn.com/number-magic/)
+
+[![Test](https://github.com/craigmcn/number-magic/actions/workflows/test.yml/badge.svg)](https://github.com/craigmcn/number-magic/actions/workflows/test.yml)
+
+Think of a number between 1 and 63. The app shows you six cards and asks whether your number appears on each one. After all six cards, it reveals your number — the trick is pure binary arithmetic: each "yes" card contributes a power of 2, and their sum is your number.
+
+A **magic mode** toggle (via the settings panel ⚙) reveals the answer automatically; in **manual mode** you add up the "yes" cards yourself.
 
 ---
 
-## VS Code settings
+## Stack
 
-I needed to set the following in `.vscode/settings.json` to ensure that ESLint was reporting issues in the *Problems*
-tab. YMMV
+- [React](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/) built with [Vite](https://vitejs.dev/)
+- [Font Awesome](https://fontawesome.com/) for icons
+- [AlbertCSS](https://albertcss.craigmcn.com/) for base styling
+- [Sass](https://sass-lang.com/) (SCSS modules) for component styles
 
-```json
-{
-  ...,
-  "eslint.enable": true,
-  "eslint.alwaysShowStatus": true,
-  "eslint.nodePath": ".yarn/sdks",
-  "eslint.packageManager": "yarn",
-  "eslint.validate": [
-    "html",
-    "javascript",
-    "typescript",
-    "javascriptreact",
-    "typescriptreact"
-  ],
-  "eslint.runtime": $(nvm which current),
-  ...
-}
+## Development
+
+```bash
+yarn install
+yarn dev        # dev server at http://localhost:3100
+yarn build      # type-check + build to dist/
+yarn lint       # ESLint (read-only — fails on any error)
+yarn lint:fix   # ESLint with auto-fix
+yarn format     # Prettier
 ```
 
-I also needed to run `yarn dlx @yarnpkg/sdks`, which was very much not obvious in any help I could find. I still don't know if it was in addition to `yarn dlx @yarnpkg/sdks vscode`.
+VS Code SDK integrations for ESLint and TypeScript are committed in `.yarn/sdks/` and configured in `.vscode/settings.json` — no extra setup needed.
+
+## Testing
+
+Vitest + Testing Library. 25 tests across component and utility tests.
+
+```bash
+yarn test        # watch mode
+yarn test:run    # single pass
+yarn coverage    # single pass with coverage report
+```
+
+## Deployment
+
+Deployed on Netlify. The build outputs to two directories simultaneously:
+
+- `dist/` — root deployment
+- `dist/number-magic/` — subdirectory deployment at `/number-magic/` on the parent domain

--- a/src/components/Result/Result.test.tsx
+++ b/src/components/Result/Result.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useReadLocalStorage } from 'usehooks-ts';
 import Result from './Result';
 
@@ -55,5 +56,14 @@ describe('Result', () => {
     expect(screen.getByRole('heading', { name: 'Your number is' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: '6' })).toBeInTheDocument(); // total of `result`
     expect(screen.getByRole('button', { name: 'Play again' })).toBeInTheDocument();
+  });
+
+  it('calls handleAgain when Play again is clicked', async () => {
+    const user = userEvent.setup();
+    render(<Result result={result} handleAgain={handleAgain} />);
+
+    await user.click(screen.getByRole('button', { name: 'Play again' }));
+
+    expect(handleAgain).toHaveBeenCalledOnce();
   });
 });

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,17 +1,19 @@
+@use 'sass:color';
+
 $spacing: 1rem;
 
 $primary: #4cb5fa;
-$primary-active: darken($primary, 12%);
+$primary-active: color.adjust($primary, $lightness: -12%);
 $primary-light: #005b99;
-$primary-light-active: darken($primary-light, 12%);
+$primary-light-active: color.adjust($primary-light, $lightness: -12%);
 $danger: #f49090;
-$danger-inactive: darken(desaturate($danger, 40%), 35%);
+$danger-inactive: color.adjust($danger, $saturation: -40%, $lightness: -35%);
 $danger-light: #b60202;
-$danger-light-inactive: lighten(desaturate($danger-light, 60%), 40%);
+$danger-light-inactive: color.adjust($danger-light, $saturation: -60%, $lightness: 40%);
 $success: #09c809;
-$success-inactive: darken(desaturate($success, 20%), 20%);
+$success-inactive: color.adjust($success, $saturation: -20%, $lightness: -20%);
 $success-light: #036803;
-$success-light-inactive: lighten(desaturate($success-light, 60%), 40%);
+$success-light-inactive: color.adjust($success-light, $saturation: -60%, $lightness: 40%);
 $black-0: #808080;
 $black-50: #7e7e7e;
 $black-100: #777;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@use 'variables' as *;
 
 :root {
   --color-default: #{$white-800};


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` (`* @craigmcn`) — cross-repo housekeeping task
- Migrate Sass `@import` → `@use` in `index.scss` and replace deprecated `darken()`/`desaturate()`/`lighten()` in `_variables.scss` with `color.adjust()` from `sass:color`
- Add `userEvent.click` test for the "Play again" button in `Result.test.tsx`, asserting `handleAgain` is called
- Remove resolved follow-up items from `CLAUDE.md`

Branch protection was also updated separately (outside this PR): required approvals changed from 0 → 1, with owner bypass via `enforce_admins: false`.

## Test plan

- [ ] `yarn test:run` — all 25 tests pass (includes new click test)
- [ ] `yarn build` — clean build, no Sass deprecation warnings
- [ ] `yarn lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)