### PR TITLE
build: add build:netlify script, simplify vite config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+netlify
 *.local
 
 # Editor directories and files

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
+    "build:netlify": "vite build --outDir netlify && vite build --outDir netlify/number-magic",
     "preview": "vite preview",
     "lint": "eslint ./src",
     "lint:fix": "eslint --fix ./src",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,14 +4,6 @@ import react from "@vitejs/plugin-react";
 // https://vitejs.dev/config/
 export default defineConfig({
   base: "./",
-  build: {
-    rollupOptions: {
-      output: [
-        { dir: "dist" },
-        { dir: "dist/number-magic" }, // For Netlify subdirectory
-      ],
-    },
-  },
   server: {
     port: 3100,
   },


### PR DESCRIPTION
## Summary

- Add `build:netlify` script that builds to `netlify/` (Netlify root) and `netlify/number-magic/` (GitHub Pages subdirectory) using explicit `--outDir` flags
- Remove the `rollupOptions` dual-output hack from `vite.config.ts` — no longer needed
- Add `netlify/` to `.gitignore`

> **Note:** If the Netlify dashboard build command is currently set to `yarn build`, update it to `yarn build:netlify` after merging.

## Test plan

- [ ] `yarn build` produces `dist/` as before
- [ ] `yarn build:netlify` produces both `netlify/` and `netlify/number-magic/` with valid output
- [ ] CI passes (format:check → lint → build → test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)